### PR TITLE
show the name of the skipped test

### DIFF
--- a/doc/examples/basic.out
+++ b/doc/examples/basic.out
@@ -1,0 +1,15 @@
+$ py.test -rsx basic.py
+============================= test session starts ==============================
+platform linux -- Python 3.4.6, pytest-2.8.7, py-1.4.30, pluggy-0.3.1
+rootdir: /home/user/pytest-dependency-0.2, inifile: 
+plugins: dependency-0.2
+collected 5 items 
+
+basic.py x.s.s
+=========================== short test summary info ============================
+SKIP [1] /usr/lib/python3.4/site-packages/pytest_dependency.py:65: test_e depends on test_c
+SKIP [1] /usr/lib/python3.4/site-packages/pytest_dependency.py:65: test_c depends on test_a
+XFAIL basic.py::test_a
+  deliberate fail
+
+================ 2 passed, 2 skipped, 1 xfailed in 0.02 seconds ================

--- a/doc/src/usage.rst
+++ b/doc/src/usage.rst
@@ -13,9 +13,13 @@ Consider the following example test module:
 All the tests are decorated with :func:`pytest.mark.dependency`.  This
 will cause the test results to be registered internally and thus other
 tests may depend on them.  The list of dependencies of a test may be
-set in the optional `depends` argument to the marker.  The first test
-has deliberately been set to fail to illustrate the effect.  We will
-get the following resuts:
+set in the optional `depends` argument to the marker.  Running this
+test, we will get the following result:
+
+.. literalinclude:: ../examples/basic.out
+
+The first test has deliberately been set to fail to illustrate the
+effect.  We will get the following resuts:
 
 `test_a`
   deliberatly fails.

--- a/pytest_dependency.py
+++ b/pytest_dependency.py
@@ -6,11 +6,9 @@ skipped if any of the dependencies did fail or has been skipped.
 """
 
 import pytest
-# from blessings import Terminal
 
 __version__   = "0.2"
 
-# terminal = Terminal()
 
 class DependencyItemStatus(object):
     """Status of a test item in a dependency manager.
@@ -64,12 +62,7 @@ class DependencyManager(object):
     def checkDepend(self, depends, item):
         for i in depends:
             if not(i in self.results and self.results[i].isSuccess()):
-                msg = "%s depends on %s (failed)" % (item.name, i)
-                # color version
-                # msg = "%s depends on %s %s" % (terminal.yellow(item.name),
-                                               # terminal.yellow(i),
-                                               # terminal.red('(failed)'))
-                pytest.skip(msg)
+                pytest.skip("%s depends on %s" % (item.name, i))
 
 
 def depends(request, other):

--- a/pytest_dependency.py
+++ b/pytest_dependency.py
@@ -6,11 +6,11 @@ skipped if any of the dependencies did fail or has been skipped.
 """
 
 import pytest
-from blessings import Terminal
+# from blessings import Terminal
 
 __version__   = "0.2"
 
-terminal = Terminal()
+# terminal = Terminal()
 
 class DependencyItemStatus(object):
     """Status of a test item in a dependency manager.

--- a/pytest_dependency.py
+++ b/pytest_dependency.py
@@ -6,9 +6,9 @@ skipped if any of the dependencies did fail or has been skipped.
 """
 
 import pytest
+from blessings import Terminal
 
 __version__   = "0.2"
-from blessings import Terminal
 
 terminal = Terminal()
 
@@ -64,9 +64,11 @@ class DependencyManager(object):
     def checkDepend(self, depends, item):
         for i in depends:
             if not(i in self.results and self.results[i].isSuccess()):
-                msg = "%s depends on %s %s" % (terminal.yellow(item.name),
-                                               terminal.yellow(i),
-                                               terminal.red('(failed)'))
+                msg = "%s depends on %s (failed)" % (item.name, i)
+                # color version
+                # msg = "%s depends on %s %s" % (terminal.yellow(item.name),
+                                               # terminal.yellow(i),
+                                               # terminal.red('(failed)'))
                 pytest.skip(msg)
 
 

--- a/tests/test_03_skipmsgs.py
+++ b/tests/test_03_skipmsgs.py
@@ -1,0 +1,39 @@
+"""Verify the messages issued when a dependent test is skipped.
+"""
+
+import pytest
+
+
+def test_simple(ctestdir):
+    """One test fails, other dependent tests are skipped.
+    This also includes indirect dependencies.
+    """
+    ctestdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.dependency()
+        def test_a():
+            pass
+
+        @pytest.mark.dependency()
+        def test_b():
+            assert False
+
+        @pytest.mark.dependency(depends=["test_b"])
+        def test_c():
+            pass
+
+        @pytest.mark.dependency(depends=["test_c"])
+        def test_d():
+            pass
+    """)
+    result = ctestdir.runpytest("--verbose", "-rs")
+    result.assert_outcomes(passed=1, skipped=2, failed=1)
+    result.stdout.fnmatch_lines("""
+        *::test_a PASSED
+        *::test_b FAILED
+        *::test_c SKIPPED
+        *::test_d SKIPPED
+        SKIP * test_c depends on test_b
+        SKIP * test_d depends on test_c
+    """)

--- a/tests/test_03_skipmsgs.py
+++ b/tests/test_03_skipmsgs.py
@@ -34,6 +34,8 @@ def test_simple(ctestdir):
         *::test_b FAILED
         *::test_c SKIPPED
         *::test_d SKIPPED
+    """)
+    result.stdout.fnmatch_lines_random("""
         SKIP * test_c depends on test_b
         SKIP * test_d depends on test_c
     """)


### PR DESCRIPTION
I would like you to consider to add this minor change for showing the name of the test that is skipped due some failed dependence.