### PR TITLE
Declare the type of automark_dependency ini-option correctly as bool

### DIFF
--- a/doc/src/changelog.rst
+++ b/doc/src/changelog.rst
@@ -5,10 +5,13 @@ dev (not yet released)
     Bug fixes and minor changes
       + `#40`_: add logging.
       + `#50`_, `#51`_: test suite incompatibility with pytest 6.2.0.
+      + `#58`_: declare the type of automark_dependency ini-option
+	correctly as bool.
 
 .. _#40: https://github.com/RKrahl/pytest-dependency/issues/40
 .. _#50: https://github.com/RKrahl/pytest-dependency/issues/50
 .. _#51: https://github.com/RKrahl/pytest-dependency/pull/51
+.. _#58: https://github.com/RKrahl/pytest-dependency/pull/58
 
 0.5.1 (2020-02-14)
     Bug fixes and minor changes

--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -11,20 +11,6 @@ _automark = False
 _ignore_unknown = False
 
 
-def _get_bool(value):
-    """Evaluate string representation of a boolean value.
-    """
-    if value:
-        if value.lower() in ["0", "no", "n", "false", "f", "off"]:
-            return False
-        elif value.lower() in ["1", "yes", "y", "true", "t", "on"]:
-            return True
-        else:
-            raise ValueError("Invalid truth value '%s'" % value)
-    else:
-        return False
-
-
 class DependencyItemStatus(object):
     """Status of a test item in a dependency manager.
     """
@@ -142,7 +128,7 @@ def depends(request, other, scope='module'):
 def pytest_addoption(parser):
     parser.addini("automark_dependency", 
                   "Add the dependency marker to all tests automatically", 
-                  default=False)
+                  type="bool", default=False)
     parser.addoption("--ignore-unknown-dependency", 
                      action="store_true", default=False, 
                      help="ignore dependencies whose outcome is not known")
@@ -150,7 +136,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     global _automark, _ignore_unknown
-    _automark = _get_bool(config.getini("automark_dependency"))
+    _automark = config.getini("automark_dependency")
     _ignore_unknown = config.getoption("--ignore-unknown-dependency")
     config.addinivalue_line("markers", 
                             "dependency(name=None, depends=[]): "

--- a/tests/test_04_automark.py
+++ b/tests/test_04_automark.py
@@ -29,7 +29,10 @@ def test_not_set(ctestdir):
     """)
 
 
-def test_set_false(ctestdir):
+@pytest.mark.parametrize(
+    "false_value", ["0", "no", "n", "False", "false", "f", "off"]
+)
+def test_set_false(ctestdir, false_value):
     """A pytest.ini is present, automark_dependency is set to false.
 
     Since automark_dependency is set to false and test_a is not
@@ -38,9 +41,9 @@ def test_set_false(ctestdir):
     """
     ctestdir.makefile('.ini', pytest="""
         [pytest]
-        automark_dependency = false
+        automark_dependency = %s
         console_output_style = classic
-    """)
+    """ % false_value)
     ctestdir.makepyfile("""
         import pytest
 
@@ -59,7 +62,10 @@ def test_set_false(ctestdir):
     """)
 
 
-def test_set_true(ctestdir):
+@pytest.mark.parametrize(
+    "true_value", ["1", "yes", "y", "True", "true", "t", "on"]
+)
+def test_set_true(ctestdir, true_value):
     """A pytest.ini is present, automark_dependency is set to false.
 
     Since automark_dependency is set to true, the outcome of test_a
@@ -68,9 +74,9 @@ def test_set_true(ctestdir):
     """
     ctestdir.makefile('.ini', pytest="""
         [pytest]
-        automark_dependency = true
+        automark_dependency = %s
         console_output_style = classic
-    """)
+    """ % true_value)
     ctestdir.makepyfile("""
         import pytest
 


### PR DESCRIPTION
Declare the type of the `automark_dependency` ini-option as `bool`.  Let pytest parse the value rather than trying to parse the boolean from a string ourselves.