### PR TITLE
Add a hint when dep is not found

### DIFF
--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -89,7 +89,7 @@ class DependencyManager(object):
                 else:
                     logger.debug("... %s has not succeeded", i)
             else:
-                logger.debug("... %s is unknown", i)
+                logger.debug("... %s is unknown (did you forget to mark it?)", i)
                 if _ignore_unknown:
                     continue
             logger.info("skip %s because it depends on %s", item.name, i)


### PR DESCRIPTION
It is a rather common mistake to forget adding the mark to tests acting as a dependency target.  This short reminder will be most useful to new users.