### PR TITLE
Include docs in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,11 @@ include LICENSE.txt
 include MANIFEST.in
 include README.rst
 include _meta.py
+include doc/Makefile
 include doc/examples/*.py
+include doc/src/*.pub
+include doc/src/*.py
+include doc/src/*.rst
 include tests/conftest.py
 include tests/pytest.ini
 include tests/test_*.py


### PR DESCRIPTION
The Debian package of pytest-dependency uses the release tarballs published on GitHub, and also builds the documentation.  The tarball for 0.5.1 included `doc/src/`, but the one for 0.6.0 doesn't.  I suspect that the 0.6.0 tarball is an sdist, so adding documentation files to the sdist should help.