### PR TITLE
Apply ruff/flake8-comprehensions rules (C4)

### DIFF
--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -18,7 +18,7 @@ class DependencyItemStatus(object):
     Phases = ('setup', 'call', 'teardown')
 
     def __init__(self):
-        self.results = { w:None for w in self.Phases }
+        self.results = dict.fromkeys(self.Phases)
 
     def __str__(self):
         l = ["%s: %s" % (w, self.results[w]) for w in self.Phases]


### PR DESCRIPTION
C420 Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead