### PR TITLE
Don't override a failing result

### DIFF
--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -25,6 +25,11 @@ class DependencyItemStatus:
         return "Status(%s)" % ", ".join(l)
 
     def addResult(self, rep):
+        existing = self.results[rep.when]
+        outcome = rep.outcome
+        if existing is not None and existing != 'passed':
+            #don't override a failng case
+            return
         self.results[rep.when] = rep.outcome
 
     def isSuccess(self):


### PR DESCRIPTION
The motivation for this change is if a module, let's call it `test_01.py` is marked with a dependency like this:
```python
import pytest
pytestmark = [
    pytest.mark.order(1),
    pytest.mark.dependency(name="01_setup", scope="session"),
]

def test_01():
    assert False

def test_01a():
    assert True
```
Then tests in a dependent test module will run instead of being skipped if `test_01` fails. 
For example `test_02.py`:
```python
import pytest
pytestmark = [
    pytest.mark.order(2),
    pytest.mark.dependency(depends=["01_setup"], name="02_setup", scope="session"),
]

def test_02():
    assert True

```
This PR makes it such that `test_02` is skipped if _any_ test fails in `test_01.py`