### PR TITLE
fix: make compatible with setuptools 81.0.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,11 @@ class copy_file_mixin:
                     outfile.chmod(S_IMODE(st[ST_MODE]))
             return (str(outfile), 1)
         else:
+            if self.dry_run:
+                return (outfile, 0)
             return distutils.file_util.copy_file(infile, outfile,
                                                  preserve_mode, preserve_times,
-                                                 not self.force, link,
-                                                 dry_run=self.dry_run)
+                                                 not self.force, link)
 
 class meta(setuptools.Command):
     description = "generate meta files"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ class copy_file_mixin:
     Subst = {'DOC': docstring, 'VERSION': version}
     def copy_file(self, infile, outfile,
                   preserve_mode=1, preserve_times=1, link=None, level=1):
+        try:
+            dry_run = self.dry_run
+        except AttributeError:
+            dry_run = False
         if infile in self.Subst_srcs:
             infile = Path(infile)
             outfile = Path(outfile)
@@ -54,7 +58,7 @@ class copy_file_mixin:
             else:
                 log.info("copying (with substitutions) %s -> %s",
                          infile, outfile)
-            if not self.dry_run:
+            if not dry_run:
                 st = infile.stat()
                 try:
                     outfile.unlink()
@@ -68,7 +72,7 @@ class copy_file_mixin:
                     outfile.chmod(S_IMODE(st[ST_MODE]))
             return (str(outfile), 1)
         else:
-            if self.dry_run:
+            if dry_run:
                 return (outfile, 1)
             return distutils.file_util.copy_file(infile, outfile,
                                                  preserve_mode, preserve_times,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ class copy_file_mixin:
             return (str(outfile), 1)
         else:
             if self.dry_run:
-                return (outfile, 0)
+                return (outfile, 1)
             return distutils.file_util.copy_file(infile, outfile,
                                                  preserve_mode, preserve_times,
                                                  not self.force, link)


### PR DESCRIPTION
This MR fixes compatibility with setuptools 81.0.0 and later, which removed the dry_run argument from distutils.file_util.copy_file. The previous implementation caused installation failures when building with modern pip/setuptools.


Testing

Verified by pip install . 

```


pip install .
Processing pytest-dependency-issue-fix
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting setuptools (from pytest-dependency==0.6.0)
  Downloading setuptools-82.0.0-py3-none-any.whl.metadata (6.6 kB)
Collecting pytest>=3.7.0 (from pytest-dependency==0.6.0)
  Downloading pytest-9.0.2-py3-none-any.whl.metadata (7.6 kB)
Collecting colorama>=0.4 (from pytest>=3.7.0->pytest-dependency==0.6.0)
  Downloading colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
Collecting iniconfig>=1.0.1 (from pytest>=3.7.0->pytest-dependency==0.6.0)
  Downloading iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
Collecting packaging>=22 (from pytest>=3.7.0->pytest-dependency==0.6.0)
  Downloading packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
Collecting pluggy<2,>=1.5 (from pytest>=3.7.0->pytest-dependency==0.6.0)
  Downloading pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
Collecting pygments>=2.7.2 (from pytest>=3.7.0->pytest-dependency==0.6.0)
  Downloading pygments-2.19.2-py3-none-any.whl.metadata (2.5 kB)
Downloading pytest-9.0.2-py3-none-any.whl (374 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 374.8/374.8 kB 11.8 MB/s eta 0:00:00
Downloading setuptools-82.0.0-py3-none-any.whl (1.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0/1.0 MB 12.6 MB/s eta 0:00:00
Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Downloading iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
Downloading packaging-26.0-py3-none-any.whl (74 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 74.4/74.4 kB ? eta 0:00:00
Downloading pluggy-1.6.0-py3-none-any.whl (20 kB)
Downloading pygments-2.19.2-py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 12.9 MB/s eta 0:00:00
Building wheels for collected packages: pytest-dependency
  Building wheel for pytest-dependency (pyproject.toml) ... done
  Created wheel for pytest-dependency: filename=pytest_dependency-0.6.0-py3-none-any.whl size=9024 sha256=f428eb506bcaaf5d8c14ef8de4c2357f84b63f332470a2c96f3c790d493d1883
  Stored in directory: C:\Users\ashutosh.kodavade\AppData\Local\Temp\pip-ephem-wheel-cache-qwuh22_5\wheels\40\ef\dc\85e479f69864ced33ab56af013ce568319d9bf56d133a3282b
Successfully built pytest-dependency
Installing collected packages: setuptools, pygments, pluggy, packaging, iniconfig, colorama, pytest, pytest-dependency
  Attempting uninstall: setuptools
    Found existing installation: setuptools 82.0.0
    Uninstalling setuptools-82.0.0:
      Successfully uninstalled setuptools-82.0.0
  Attempting uninstall: pygments
    Found existing installation: Pygments 2.19.2
    Uninstalling Pygments-2.19.2:
      Successfully uninstalled Pygments-2.19.2
  Attempting uninstall: pluggy
    Found existing installation: pluggy 1.6.0
    Uninstalling pluggy-1.6.0:
      Successfully uninstalled pluggy-1.6.0
  Attempting uninstall: packaging
    Found existing installation: packaging 26.0
    Uninstalling packaging-26.0:
      Successfully uninstalled packaging-26.0
  Attempting uninstall: iniconfig
    Found existing installation: iniconfig 2.3.0
    Uninstalling iniconfig-2.3.0:
      Successfully uninstalled iniconfig-2.3.0
  Attempting uninstall: colorama
    Found existing installation: colorama 0.4.6
    Uninstalling colorama-0.4.6:
      Successfully uninstalled colorama-0.4.6
  Attempting uninstall: pytest
    Found existing installation: pytest 9.0.2
    Uninstalling pytest-9.0.2:
      Successfully uninstalled pytest-9.0.2
Successfully installed colorama-0.4.6 iniconfig-2.3.0 packaging-26.0 pluggy-1.6.0 pygments-2.19.2 pytest-9.0.2 pytest-dependency-0.6.0 setuptools-82.0.0

[notice] A new release of pip is available: 24.0 -> 26.0.1
[notice] To update, run: python.exe -m pip install --upgrade pip


Versions- 

(venv) PS pytest-dependency-issue-fix> pip show pytest-dependency  
Name: pytest-dependency
Version: 0.6.0
Summary: Manage dependencies of tests
Home-page: https://github.com/RKrahl/pytest-dependency
Author: Rolf Krahl
Author-email: rolf@rotkraut.de
License: Apache-2.0
Location: pytest-dependency-issue-fix\venv\Lib\site-packages       
Requires: pytest, setuptools
Required-by:






(venv) PS pytest-dependency-issue-fix> pip show setuptools
Name: setuptools
Version: 82.0.0
Summary: Easily download, build, install, upgrade, and uninstall Python packages
Home-page:
Author:
Author-email: Python Packaging Authority <distutils-sig@python.org>
License:
Location: pytest-dependency-issue-fix\venv\Lib\site-packages       
Requires:
Required-by: pytest-dependency
(venv) PS pytest-dependency-issue-fix> 
```